### PR TITLE
Add await calls to queries

### DIFF
--- a/app/src/main/kotlin/nl/ndat/tvlauncher/data/repository/AppRepository.kt
+++ b/app/src/main/kotlin/nl/ndat/tvlauncher/data/repository/AppRepository.kt
@@ -24,7 +24,7 @@ class AppRepository(
 				.map { id -> database.apps.removeById(id) }
 
 			// Upsert all found
-			apps.map { app -> commitApp(app) }
+			apps.map { app -> commitApp(app).await() }
 		}
 	}
 
@@ -55,6 +55,6 @@ class AppRepository(
 	suspend fun getByPackageName(packageName: String) = withContext(Dispatchers.IO) { database.apps.getByPackageName(packageName).awaitAsOneOrNull() }
 
 	suspend fun favorite(id: String) = withContext(Dispatchers.IO) { database.apps.updateFavoriteAdd(id) }
-	suspend fun unfavorite(id: String) = withContext(Dispatchers.IO) { database.apps.updateFavoriteRemove(id) }
-	suspend fun updateFavoriteOrder(id: String, order: Int) = withContext(Dispatchers.IO) { database.apps.updateFavoriteOrder(id, order.toLong()) }
+	suspend fun unfavorite(id: String) = withContext(Dispatchers.IO) { database.apps.updateFavoriteRemove(id).await() }
+	suspend fun updateFavoriteOrder(id: String, order: Int) = withContext(Dispatchers.IO) { database.apps.updateFavoriteOrder(id, order.toLong()).await() }
 }

--- a/app/src/main/kotlin/nl/ndat/tvlauncher/data/repository/ChannelRepository.kt
+++ b/app/src/main/kotlin/nl/ndat/tvlauncher/data/repository/ChannelRepository.kt
@@ -54,7 +54,7 @@ class ChannelRepository(
 				.map { id -> database.channelPrograms.removeById(id) }
 
 			// Upsert channels
-			programs.map { program -> commitChannelProgram(program) }
+			programs.map { program -> commitChannelProgram(program).await() }
 		}
 	}
 


### PR DESCRIPTION
The constructed queries were not executed as nothing was awaiting the result. This made it impossible to rearrange the favorites or unfavorite apps. New apps also did not show up, and a fresh install had no channels and no apps.

I'm not sure if this is the neat way to solve it. At least it fixed the problem for me.